### PR TITLE
run-server: portably invoke bash

### DIFF
--- a/game/run-server.sh
+++ b/game/run-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p ./secrets
 touch ./secrets/.pre-shared-key


### PR DESCRIPTION
freebsd bash (for example) isn't in /usr/bin/.